### PR TITLE
add expect partial to load weights in evaluation script

### DIFF
--- a/ML_Keras/evaluate.py
+++ b/ML_Keras/evaluate.py
@@ -48,9 +48,9 @@ def main():
     if os.path.isdir(ops.model_weights):
         latest = tf.train.latest_checkpoint(ops.model_weights)
         log.info(f"Using latest weights from checkpoint directory: {latest}")
-        model.load_weights(latest)
+        model.load_weights(latest).expect_partial()
     else:
-        model.load_weights(ops.model_weights)
+        model.load_weights(ops.model_weights).expect_partial()
     x, y, normweight = get_full_data(conf["file"])
 
     # prepare data


### PR DESCRIPTION
Add expect partial to load weights because the model is loading training information (such as optimizer info) but we are only using it for inference so tensorflow reports a warning. See https://stackoverflow.com/questions/58289342/tf2-0-translation-model-error-when-restoring-the-saved-model-unresolved-objec