### PR TITLE
Get statistically independent training/validation data

### DIFF
--- a/ML_Keras/conf_example.json
+++ b/ML_Keras/conf_example.json
@@ -8,5 +8,5 @@
    "input_dim": 1,
    "ndense": 2,
    "nnode_per_dense": 30,
-   "tf_seed": 1
+   "seed": 1
 }

--- a/ML_Keras/evaluate.py
+++ b/ML_Keras/evaluate.py
@@ -14,6 +14,7 @@ import argparse
 import json
 import tensorflow as tf
 import os
+import sys
 import logging
 
 # custom code
@@ -44,6 +45,11 @@ def main():
             "ndense" : ops.ndense,
             "nnode_per_dense" : ops.nnode_per_dense
         }
+
+    # protection
+    if ops.model_weights is None:
+      print('ERROR: no model weights were provided, exiting')
+      sys.exit(1)
 
     # load model
     model = make_model(input_dim=conf["input_dim"], ndense=conf["ndense"], nnode_per_dense=conf["nnode_per_dense"], learning_rate=1e-3)

--- a/ML_Keras/evaluate.py
+++ b/ML_Keras/evaluate.py
@@ -48,8 +48,8 @@ def main():
 
     # protection
     if ops.model_weights is None:
-      print('ERROR: no model weights were provided, exiting')
-      sys.exit(1)
+        log.error('ERROR: no model weights were provided, exiting')
+        sys.exit(1)
 
     # load model
     model = make_model(input_dim=conf["input_dim"], ndense=conf["ndense"], nnode_per_dense=conf["nnode_per_dense"], learning_rate=1e-3)

--- a/ML_Keras/train.py
+++ b/ML_Keras/train.py
@@ -64,14 +64,14 @@ def main():
     # data set generators
     seed = None
     if "seed" in conf and conf["seed"] is not None:
-      seed = conf["seed"]
+        seed = conf["seed"]
     train_data_gen = get_data(conf["file"], conf["nepochs"], conf["train_batch_size"], seed)
     # sample validation data from the same probability density function (but generated val data is statistically independent w.r.t training data)
     val_data_gen = get_data(conf["file"], conf["nepochs"], conf["val_batch_size"], seed+1 if seed is not None else None)
 
     # set seeds to get reproducible results (only if requested)
     if seed is not None:
-      tf.keras.utils.set_random_seed(seed)
+        tf.keras.utils.set_random_seed(seed)
 
     # make model
     model = make_model(input_dim=conf["input_dim"], ndense=conf["ndense"], nnode_per_dense=conf["nnode_per_dense"], learning_rate=conf["learning_rate"])


### PR DESCRIPTION
New:
- -tfs / --tf_seed -> -s / --seed
- Exit if no model weights are provided in evaluate.py (instead of crashing)
- Fix get_data.py to work on LXPLUS (on debug mode)
- Remove hardcoding of seed in get_data.py. Now no seed is used unless provided.
- train.py now passes different seeds (or None) to get_data() to get statistically independent training/validation datasets
- Minor fixes to comments, type hints, etc